### PR TITLE
Fix cli.js sintax error

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ var cli = meow({
     '  => `Last Quarter - 🌗`',
     '',
     '  moonmoji --version',
-    `  => \`${version}\``
+    '  => ' + version
   ].join('\n')
 })
 


### PR DESCRIPTION
Fix error when run moonmoji from command line
```
$ moonmoji 
/usr/lib/node_modules/moonmoji/cli.js:19
    `  => \`${version}\``
    ^
SyntaxError: Unexpected token ILLEGAL
    at exports.runInThisContext (vm.js:73:16)
    at Module._compile (module.js:443:25)
    at Object.Module._extensions..js (module.js:478:10)
    at Module.load (module.js:355:32)
    at Function.Module._load (module.js:310:12)
    at Function.Module.runMain (module.js:501:10)
    at startup (node.js:129:16)
    at node.js:814:3
```